### PR TITLE
Ability to filter out non-cmo requests

### DIFF
--- a/src/main/java/org/mskcc/cmo/metadb/irt_publisher/IRTReader.java
+++ b/src/main/java/org/mskcc/cmo/metadb/irt_publisher/IRTReader.java
@@ -34,6 +34,9 @@ public class IRTReader implements ItemStreamReader<String> {
     @Value("#{jobParameters[daysBack]}")
     private String daysBack;
 
+    @Value("#{jobParameters[cmoRequestsOnly]}")
+    private Boolean cmoRequestsOnly;
+
     @Autowired
     private IRTUtil irtUtil;
 
@@ -43,7 +46,7 @@ public class IRTReader implements ItemStreamReader<String> {
     public void open(ExecutionContext ec) throws ItemStreamException {
         LOG.info("Fetching request ids from IRT going back: " + daysBack + " days.");
         try {
-            this.requestIdsList = irtUtil.getRequestIds(daysBack);
+            this.requestIdsList = irtUtil.getRequestIds(daysBack, cmoRequestsOnly);
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }


### PR DESCRIPTION
Added command-line argument to filter requests based on isCmoRequest json property.  Default is false.