### PR TITLE
1.2.0.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,10 @@
     <jackson.version>2.11.2</jackson.version>
     <!-- metadb messaging -->
     <cmo_metadb_messaging_java.group>com.github.mskcc</cmo_metadb_messaging_java.group>
-    <cmo_metadb_messaging_java.version>1.1.8.RELEASE</cmo_metadb_messaging_java.version>
+    <cmo_metadb_messaging_java.version>1.2.0.RELEASE</cmo_metadb_messaging_java.version>
     <!-- metadb common centralized config properties -->
     <cmo_metadb_common.groupId>com.github.mskcc</cmo_metadb_common.groupId>
-    <cmo_metadb_common.version>1.1.9.RELEASE</cmo_metadb_common.version>
+    <cmo_metadb_common.version>1.2.0.RELEASE</cmo_metadb_common.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Update Metadb dependencies to `1.2.0.RELEASE`
